### PR TITLE
Fix Python 3.8 type hint in generate()

### DIFF
--- a/core/api.py
+++ b/core/api.py
@@ -1,7 +1,8 @@
 # Ollama API call logic for v0
 import requests
+from typing import Optional, List, Dict
 
-def generate(prompt: str, model: str, history: list | None = None) -> str:
+def generate(prompt: str, model: str, history: Optional[List[Dict[str, str]]] = None) -> str:
     """
     Generate a response from the LLM, including previous chat history as context.
     history: list of dicts, e.g. [{"role": "user", "content": "hi"}, {"role": "assistant", "content": "hello!"}]


### PR DESCRIPTION
## Summary
- import typing utilities for optional type hints
- avoid Python 3.10 union syntax in `generate`

## Testing
- `python -m py_compile core/api.py ui/main_window.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_6863f8314778832298045baafc41d958