### PR TITLE
Fix syntax highlighting example

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -69,7 +69,7 @@ A PyQt5-based desktop interface to interact with locally hosted Ollama LLMs.
 
 ### Syntax Highlighting
 - [ ] Use `QSyntaxHighlighter` for `QPlainTextEdit` fallback mode
-- [ ] Language detection from code block (e.g., ```python)
+- [ ] Language detection from code block (e.g., ```python ... ``` )
 
 ### Debugging
 - [ ] Display token estimate (use `tiktoken` or similar)


### PR DESCRIPTION
## Summary
- correct code fence example in TODO

## Testing
- `python -m py_compile main.py core/*.py ui/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6863faf35db08322b1ad7802f60d32be